### PR TITLE
Allow DateType to be null in where filter

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1537,6 +1537,9 @@ DataAccessObject._normalize = function(filter, options) {
 };
 
 function DateType(arg) {
+  if (arg == null || arg == 'null') {
+    return null;
+  }
   var d = new Date(arg);
   if (isNaN(d.getTime())) {
     throw new Error(g.f('Invalid date: %s', arg));


### PR DESCRIPTION
### Description

This lets us filter using `{ where : { some_date_property: null } } ` -  the string comparison is needed so that it worked on a HTTP request.

Testing:

Before - a query like the following failed with a 500:
```
http://localhost:3000/api/MyThing?filter={"where":{"some_date_property":"null"}}
http://localhost:3000/api/MyThing?filter={"where":{"some_date_property":{"neq":"null"}}}
```

After - now it works



#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
